### PR TITLE
Cookies button fix

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -220,19 +220,6 @@ h2 {
 	align-self: center;
 }
 
-.cookie-btn {
-	background-color: rgb(240, 240, 240);
-	border: none;
-	color: #262626;
-	margin: 1.2rem 0;
-}
-
-.cookie-btn:hover {
-	background-color: white;
-	border: 1px solid #262626;
-	color: #262626;
-}
-
 /* follow us styling for container */
 .followUs {
 	text-align: center;
@@ -315,6 +302,12 @@ footer {
 .btn-white {
 	background-color: #fff;
 	color: #777;
+	margin: 1.2rem 0;
+}
+
+.btn-grey {
+	background-color: var(--shaded-gray);
+	color: var(--dark-clr);
 	margin: 1.2rem 0;
 }
 

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -49,7 +49,7 @@ renamed, repurposed, deleted, etc --}}
         </p>
 
           <div class="text-box"> 
-            <a href="/cookies" class="btn btn-dark btn-        animate cookie-btn">View Cookies</a>
+            <a href="/cookies" class="btn btn-grey btn-animate ">View Cookies</a>
           </div>
 
         </div>


### PR DESCRIPTION
In this fix the cookies button was detected and removed by an ad blocker, after some changes and style fixes to the button when focused it now appears correctly, also on hover moved the whole page which is now corrected as well. Testing on pop umai second live page had no issues and worked perfectly.